### PR TITLE
spi: use gpio_dt_spec in struct spi_cs_control

### DIFF
--- a/platform/deca_spi.c
+++ b/platform/deca_spi.c
@@ -76,19 +76,19 @@ int openspi(void)
     LOG_INF("%s bus %s", __func__, DT_LABEL(DWM_SPI));
 
     /* Propagate CS config into all spi_cfgs[] elements */
-    cs_ctrl.gpio_dev = device_get_binding(DT_LABEL(DWM_CS_GPIO));
-    if (!cs_ctrl.gpio_dev) {
+    cs_ctrl.gpio.port = device_get_binding(DT_LABEL(DWM_CS_GPIO));
+    if (!cs_ctrl.gpio.port) {
         LOG_ERR("%s: GPIO binding failed.\n", __func__);
         return -1;
     }
-    cs_ctrl.gpio_pin = DWM_CS_PIN;
+    cs_ctrl.gpio.pin = DWM_CS_PIN;
     cs_ctrl.delay = 0U;
-    cs_ctrl.gpio_dt_flags = DWM_CS_FLAGS;
+    cs_ctrl.gpio.dt_flags = DWM_CS_FLAGS;
     for (int i=0; i < SPI_CFGS_COUNT; i++) {
         spi_cfgs[i].cs = &cs_ctrl;
     }
 
-    gpio_pin_set(cs_ctrl.gpio_dev, DWM_CS_PIN, 1);
+    gpio_pin_set(cs_ctrl.gpio.port, DWM_CS_PIN, 1);
 
     spi_cfg = &spi_cfgs[0];
 


### PR DESCRIPTION
Update to use the new `gpio_dt_spec` in `struct spi_cs_control`. 

See https://github.com/zephyrproject-rtos/zephyr/commit/89d76e9bbe60232e68fae039f3a21c8422ca9810 which landed in Zephyr 3.0.0. The old fields were subsequently deprecated in Zephyr 3.1.0 (https://github.com/zephyrproject-rtos/zephyr/commit/536fe6a948c9a546bb89dc73ab4adbd3b13b3e71) and then removed in Zephyr 3.2.0 ( https://github.com/zephyrproject-rtos/zephyr/commit/7b6c1b158b6a8e87b0dfcd7d173dcb006f082faf), so this PR, while compatible with 3.0.0, sets things up for later versions of Zephyr.